### PR TITLE
[FIX] : 거래내역 수정 시 금액에서 발생하는 버그 해결

### DIFF
--- a/src/components/TransactionModal.vue
+++ b/src/components/TransactionModal.vue
@@ -187,7 +187,7 @@
                     >
                       <input
                         type="text"
-                        v-model="transaction.amount"
+                        v-model="EditAmountText"
                         :disabled="!isEditable.amount"
                         class="form-control"
                         :class="isEditable.amount ? 'editable-input' : ''"
@@ -349,6 +349,29 @@ const amountText = computed({
       errorMsg.amount = ''
     } else {
       newTransaction.amount = null
+      errorMsg.amount = '금액은 0으로 시작하지 않는 숫자만 입력 가능합니다.'
+    }
+  },
+})
+
+const EditAmountText = computed({
+  get() {
+    return transaction.value.amount ? transaction.value.amount.toLocaleString() : ''
+  },
+  set(val) {
+    const raw = val.replace(/,/g, '')
+
+    if (/^[1-9]\d*$/.test(raw)) {
+      if (raw.length > 15) {
+        errorMsg.amount = '금액은 15자리 이하만 입력 가능합니다.'
+      } else {
+        transaction.value.amount = parseInt(raw)
+        errorMsg.amount = ''
+      }
+    } else if (raw === '') {
+      errorMsg.amount = ''
+    } else {
+      transaction.value.amount = null
       errorMsg.amount = '금액은 0으로 시작하지 않는 숫자만 입력 가능합니다.'
     }
   },


### PR DESCRIPTION
### 진행사항
- 수정할 때의 금액 입력이 숫자가 아닌 문자열로 입력되어 치명적인 버그 발생
- 입력과 마찬가지로 computed로 감시하며 값의 변동에 따른 로직 추가 및 숫자 형태로 변환하도록 수정