### PR TITLE
[FIX] :  거래내역 추가, 수정 시 금액 입력 문제 해결

### DIFF
--- a/src/components/TransactionModal.vue
+++ b/src/components/TransactionModal.vue
@@ -340,6 +340,7 @@ const amountText = computed({
 
     if (/^[1-9]\d*$/.test(raw)) {
       if (raw.length > 15) {
+        newTransaction.amount = null
         errorMsg.amount = '금액은 15자리 이하만 입력 가능합니다.'
       } else {
         newTransaction.amount = parseInt(raw)
@@ -364,6 +365,7 @@ const EditAmountText = computed({
 
     if (/^[1-9]\d*$/.test(raw)) {
       if (raw.length > 15) {
+        transaction.value.amount = null
         errorMsg.amount = '금액은 15자리 이하만 입력 가능합니다.'
       } else {
         transaction.value.amount = parseInt(raw)

--- a/src/components/TransactionModal.vue
+++ b/src/components/TransactionModal.vue
@@ -346,6 +346,7 @@ const amountText = computed({
         errorMsg.amount = ''
       }
     } else if (raw === '') {
+      transaction.value.amount = null
       errorMsg.amount = ''
     } else {
       newTransaction.amount = null
@@ -369,6 +370,7 @@ const EditAmountText = computed({
         errorMsg.amount = ''
       }
     } else if (raw === '') {
+      transaction.value.amount = null
       errorMsg.amount = ''
     } else {
       transaction.value.amount = null


### PR DESCRIPTION
### 진행 사항
- 금액 수정 시 공백이나 15자리보다 큰 금액을 입력해도 수정이 되는 문제 해결
- 금액 저장 시 15자리보다 큰 금액을 입력해도 저장이 되는 문제 해결